### PR TITLE
Add token-gated polls app

### DIFF
--- a/components/apps/Polls.tsx
+++ b/components/apps/Polls.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { usePolls } from '@/hooks/usePolls';
+import { Poll } from '@/types/Poll';
+import { useUserAddress, useKrauseBalance } from '@/hooks/ethereum';
+import { useSignIn } from '@/hooks/sign-in/useSignIn';
+
+const PollCreator = ({ add, disabled }: { add: (q: string, o: string[]) => void; disabled: boolean }) => {
+  const [question, setQuestion] = useState('');
+  const [options, setOptions] = useState<string[]>(['', '']);
+
+  const updateOption = (i: number, value: string) => {
+    setOptions(options.map((o, idx) => (idx === i ? value : o)));
+  };
+
+  const addOption = () => setOptions([...options, '']);
+
+  const create = () => {
+    if (disabled) return;
+    const opts = options.filter((o) => o.trim());
+    if (!question.trim() || opts.length < 2) return;
+    add(question, opts);
+    setQuestion('');
+    setOptions(['', '']);
+  };
+
+  return (
+    <div className="border p-4 rounded space-y-2">
+      <p className="text-xl font-semibold">Create Poll</p>
+      <input
+        className="border p-1 w-full"
+        placeholder="Question"
+        value={question}
+        disabled={disabled}
+        onChange={(e) => setQuestion(e.target.value)}
+      />
+      {options.map((opt, i) => (
+        <input
+          key={i}
+          className="border p-1 w-full mt-1"
+          placeholder={`Option ${i + 1}`}
+          value={opt}
+          disabled={disabled}
+          onChange={(e) => updateOption(i, e.target.value)}
+        />
+      ))}
+      <button className="text-sm underline" disabled={disabled} onClick={addOption}>
+        Add option
+      </button>
+      <button className="bg-primary text-white px-3 py-1 rounded" disabled={disabled} onClick={create}>
+        Create
+      </button>
+      {disabled && <p className="text-sm text-warning">Connect wallet with $KRAUSE to create polls.</p>}
+    </div>
+  );
+};
+
+const PollCard = ({ poll, onVote, disabled }: { poll: Poll; onVote: any; disabled: boolean }) => {
+  const [option, setOption] = useState(poll.options[0]?.id);
+  const [comment, setComment] = useState('');
+
+  const submit = () => {
+    if (disabled) return;
+    onVote(poll.id, option, { address: address || '', weight: balance, comment });
+    setComment('');
+  };
+
+  const weightSum = (opt: any) => opt.votes.reduce((s: number, v: any) => s + v.weight, 0);
+
+  const address = useUserAddress();
+  const balance = Number(useKrauseBalance(address));
+
+  return (
+    <div className="border p-4 rounded space-y-2 mt-4">
+      <p className="text-lg font-medium">{poll.question}</p>
+      {poll.options.map((o) => (
+        <div key={o.id} className="ml-2">
+          <p className="font-semibold">{o.text}</p>
+          <p className="text-sm">Addresses: {o.votes.length} &middot; Weight: {weightSum(o)}</p>
+          <ul className="list-disc ml-5 text-sm">
+            {o.votes.map((v, i) => (
+              <li key={i}>
+                {v.address} - {v.weight}
+                {v.comment ? ` (${v.comment})` : ''}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+      <div className="flex flex-col space-y-1">
+        <select className="border p-1" value={option} disabled={disabled} onChange={(e) => setOption(Number(e.target.value))}>
+          {poll.options.map((o) => (
+            <option key={o.id} value={o.id}>
+              {o.text}
+            </option>
+          ))}
+        </select>
+        <input className="border p-1" placeholder="Comment" value={comment} disabled={disabled} onChange={(e) => setComment(e.target.value)} />
+        <button className="bg-primary text-white px-2 py-1 rounded" disabled={disabled} onClick={submit}>
+          Vote
+        </button>
+        {disabled && <p className="text-sm text-warning">Connect wallet with $KRAUSE to vote.</p>}
+      </div>
+    </div>
+  );
+};
+
+export default function PollsApp() {
+  const { polls, addPoll, vote } = usePolls();
+  const address = useUserAddress();
+  const balance = Number(useKrauseBalance(address));
+  const { signedIn } = useSignIn();
+  const canInteract = signedIn && balance > 0;
+
+  return (
+    <div className="p-4 space-y-4">
+      <PollCreator add={addPoll} disabled={!canInteract} />
+      {polls.map((p) => (
+        <PollCard key={p.id} poll={p} onVote={vote} disabled={!canInteract} />
+      ))}
+    </div>
+  );
+}

--- a/components/apps/__tests__/Polls.test.tsx
+++ b/components/apps/__tests__/Polls.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { expect } from 'chai';
+import PollsApp from '../Polls';
+
+const mockUseSignIn = jest.fn();
+jest.mock('@/hooks/sign-in/useSignIn', () => ({ useSignIn: () => mockUseSignIn() }));
+
+const mockUseKrauseBalance = jest.fn();
+const mockUseUserAddress = jest.fn();
+jest.mock('@/hooks/ethereum', () => ({
+  useUserAddress: () => mockUseUserAddress(),
+  useKrauseBalance: () => mockUseKrauseBalance(),
+}));
+
+jest.mock('@/hooks/usePolls', () => ({
+  usePolls: () => ({ polls: [], addPoll: jest.fn(), vote: jest.fn() }),
+}));
+
+describe('Polls gating', () => {
+  it('disables interaction when not signed in or no balance', () => {
+    mockUseSignIn.mockReturnValue({ signedIn: false });
+    mockUseUserAddress.mockReturnValue('0x1');
+    mockUseKrauseBalance.mockReturnValue('0');
+    render(<PollsApp />);
+    expect(screen.getByText(/Connect wallet with \$KRAUSE to create polls/i)).to.exist;
+    expect(screen.getByText(/Connect wallet with \$KRAUSE to vote/i)).to.exist;
+  });
+
+  it('allows interaction with balance and sign in', () => {
+    mockUseSignIn.mockReturnValue({ signedIn: true });
+    mockUseUserAddress.mockReturnValue('0x1');
+    mockUseKrauseBalance.mockReturnValue('10');
+    render(<PollsApp />);
+    expect(screen.queryByText(/Connect wallet with \$KRAUSE to create polls/i)).to.be.null;
+  });
+});

--- a/components/home/DesktopIcons.tsx
+++ b/components/home/DesktopIcons.tsx
@@ -11,6 +11,7 @@ export function DesktopIcons() {
     launchProfile,
     launchSearch,
     launchProposalView,
+    launchPolls,
   } = useAppLauncher();
 
   return (
@@ -56,6 +57,17 @@ export function DesktopIcons() {
             alt="Proposals"
           />
           <p className="font-mono">Proposals</p>
+        </div>
+      </button>
+      <button onClick={launchPolls}>
+        <div className="flex flex-col items-center space-y-1">
+          <Image
+            src="/desktop-icons/Files.png"
+            width={40}
+            height={50}
+            alt="Polls"
+          />
+          <p className="font-mono">Polls</p>
         </div>
       </button>
       {/* <div

--- a/components/home/DesktopIconsBasic.tsx
+++ b/components/home/DesktopIconsBasic.tsx
@@ -9,6 +9,7 @@ import { toggle } from "@/redux/features/windows/windowsSlice";
 export function DesktopIconsBasic() {
   const dispatch = useAppDispatch();
   const toggleSearch = () => dispatch(toggle({ windowName: "search" }));
+  const { launchPolls } = useAppLauncher();
   return (
     <div className="absolute bottom-12 w-full flex-row justify-between px-16 sm:left-10 sm:top-24 sm:flex sm:w-fit sm:flex-col  sm:justify-start sm:space-x-0 sm:space-y-8 sm:px-0">
       <a target="_blank" href="https://www.krausehouse.club/media/">
@@ -78,6 +79,17 @@ export function DesktopIconsBasic() {
           <p className="font-mono">Voting</p>
         </div>
       </a>
+      <button onClick={launchPolls}>
+        <div className="flex flex-col items-center space-y-1">
+          <Image
+            alt="Polls"
+            src="/desktop-icons/Files.png"
+            width={50}
+            height={50}
+          />
+          <p className="font-mono">Polls</p>
+        </div>
+      </button>
     </div>
   );
 }

--- a/hooks/useAppLauncher.tsx
+++ b/hooks/useAppLauncher.tsx
@@ -3,6 +3,7 @@ import { useAppDispatch } from "@/redux/app/hooks";
 import { launch, open, quitApp } from "@/redux/features/windows/windowsSlice";
 import MyProfile from "../components/apps/UserProfile";
 import ProposalsListPage from "../components/apps/ProposalList";
+import PollsApp from "../components/apps/Polls";
 import SignupModal from "../components/SignupModal";
 
 export const useAppLauncher = () => {
@@ -11,6 +12,7 @@ export const useAppLauncher = () => {
     launchCreateProfile: () => dispatch(launch({ app: <SignupModal /> })),
     launchProfile: () => dispatch(launch({ app: <MyProfile />, padding: 0 })),
     launchProposalView: () => dispatch(launch({ app: <ProposalsListPage /> })),
+    launchPolls: () => dispatch(launch({ app: <PollsApp /> })),
     launchSearch: () => dispatch(open({ windowName: "search" })),
     launchProposal: (id: string) => () =>
       dispatch(launch({ app: <ProposalPage id={id} /> })),

--- a/hooks/usePolls.ts
+++ b/hooks/usePolls.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { Poll, PollOption, Vote } from '@/types/Poll';
+
+const load = (): Poll[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const data = localStorage.getItem('polls');
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+};
+
+export const usePolls = () => {
+  const [polls, setPolls] = useState<Poll[]>(load);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('polls', JSON.stringify(polls));
+    }
+  }, [polls]);
+
+  const addPoll = (question: string, options: string[]) => {
+    const poll: Poll = {
+      id: Date.now().toString(),
+      question,
+      options: options.map((text, i) => ({ id: i, text, votes: [] })),
+    };
+    setPolls((p) => [...p, poll]);
+  };
+
+  const vote = (pollId: string, optionId: number, vote: Vote) => {
+    setPolls((prev) =>
+      prev.map((p) =>
+        p.id === pollId
+          ? {
+              ...p,
+              options: p.options.map((o) =>
+                o.id === optionId ? { ...o, votes: [...o.votes, vote] } : o
+              ),
+            }
+          : p
+      )
+    );
+  };
+
+  return { polls, addPoll, vote };
+};

--- a/pages/polls.tsx
+++ b/pages/polls.tsx
@@ -1,0 +1,12 @@
+import dynamic from 'next/dynamic';
+import PollsApp from '@/components/apps/Polls';
+
+const Layout = dynamic(() => import('../components/home/Layout'));
+
+export default function PollsPage() {
+  return (
+    <Layout fixedOpen={false} noOpacity={true}>
+      <PollsApp />
+    </Layout>
+  );
+}

--- a/types/Poll.ts
+++ b/types/Poll.ts
@@ -1,0 +1,17 @@
+export interface Vote {
+  address: string;
+  weight: number;
+  comment?: string;
+}
+
+export interface PollOption {
+  id: number;
+  text: string;
+  votes: Vote[];
+}
+
+export interface Poll {
+  id: string;
+  question: string;
+  options: PollOption[];
+}


### PR DESCRIPTION
## Summary
- implement `PollsApp` with token and login gating
- attach Polls app to app launcher and desktop icons
- update `/polls` route to render PollsApp
- test gating behavior for Polls

## Testing
- `yarn test:ci` *(fails: package not in lockfile)*