### PR TITLE
Add simple DAO poll interface

### DIFF
--- a/components/apps/Polls.test.tsx
+++ b/components/apps/Polls.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PollsApp from './Polls';
+import { useUserAddress, useKrauseBalance } from '@/hooks/ethereum';
+
+jest.mock('@/hooks/ethereum');
+jest.mock('@/hooks/usePolls', () => ({
+  usePolls: () => ({ polls: [], addPoll: jest.fn(), vote: jest.fn() })
+}));
+
+const mockedUseUserAddress = useUserAddress as jest.Mock;
+const mockedUseKrauseBalance = useKrauseBalance as jest.Mock;
+
+describe('PollsApp gating', () => {
+  it('prompts to connect when wallet not connected', () => {
+    mockedUseUserAddress.mockReturnValue(null);
+    mockedUseKrauseBalance.mockReturnValue('0');
+    render(<PollsApp />);
+    expect(screen.getByText(/connect a wallet/i)).toBeInTheDocument();
+  });
+
+  it('shows creator when wallet has balance', () => {
+    mockedUseUserAddress.mockReturnValue('0x123');
+    mockedUseKrauseBalance.mockReturnValue('1');
+    render(<PollsApp />);
+    expect(screen.queryByText(/connect a wallet/i)).toBeNull();
+    expect(screen.getByText(/create poll/i)).toBeInTheDocument();
+  });
+});

--- a/components/apps/Polls.tsx
+++ b/components/apps/Polls.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { usePolls } from '@/hooks/usePolls';
+import { Poll } from '@/types/Poll';
+import { useUserAddress, useKrauseBalance } from '@/hooks/ethereum';
+
+const PollCreator = ({ add, disabled }: { add: (q: string, o: string[]) => void; disabled: boolean }) => {
+  const [question, setQuestion] = useState('');
+  const [options, setOptions] = useState<string[]>(['', '']);
+
+  const updateOption = (i: number, value: string) => {
+    setOptions(options.map((o, idx) => (idx === i ? value : o)));
+  };
+
+  const addOption = () => setOptions([...options, '']);
+
+  const create = () => {
+    const opts = options.filter((o) => o.trim());
+    if (!question.trim() || opts.length < 2) return;
+    add(question, opts);
+    setQuestion('');
+    setOptions(['', '']);
+  };
+
+  if (disabled) {
+    return <p className="italic">Connect a wallet with $KRAUSE to create polls.</p>;
+  }
+
+  return (
+    <div className="border p-4 rounded space-y-2 bg-base-100">
+      <p className="text-xl font-semibold">Create Poll</p>
+      <input
+        className="border p-1 w-full"
+        placeholder="Question"
+        value={question}
+        onChange={(e) => setQuestion(e.target.value)}
+      />
+      {options.map((opt, i) => (
+        <input
+          key={i}
+          className="border p-1 w-full mt-1"
+          placeholder={`Option ${i + 1}`}
+          value={opt}
+          onChange={(e) => updateOption(i, e.target.value)}
+        />
+      ))}
+      <button className="text-sm underline" onClick={addOption}>
+        Add option
+      </button>
+      <button className="bg-primary text-white px-3 py-1 rounded" onClick={create}>
+        Create
+      </button>
+    </div>
+  );
+};
+
+const PollCard = ({ poll, onVote, disabled }: { poll: Poll; onVote: any; disabled: boolean }) => {
+  const [option, setOption] = useState(poll.options[0]?.id);
+  const [address, setAddress] = useState('');
+  const [weight, setWeight] = useState('');
+  const [comment, setComment] = useState('');
+
+  const submit = () => {
+    if (!address || !weight) return;
+    onVote(poll.id, option, { address, weight: Number(weight), comment });
+    setAddress('');
+    setWeight('');
+    setComment('');
+  };
+
+  const weightSum = (opt: any) => opt.votes.reduce((s: number, v: any) => s + v.weight, 0);
+
+  return (
+    <div className="border p-4 rounded space-y-2 mt-4 bg-base-100">
+      <p className="text-lg font-medium">{poll.question}</p>
+      {poll.options.map((o) => (
+        <div key={o.id} className="ml-2">
+          <p className="font-semibold">{o.text}</p>
+          <p className="text-sm">Addresses: {o.votes.length} &middot; Weight: {weightSum(o)}</p>
+          <ul className="list-disc ml-5 text-sm">
+            {o.votes.map((v, i) => (
+              <li key={i}>
+                {v.address} - {v.weight}
+                {v.comment ? ` (${v.comment})` : ''}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+      {!disabled && (
+        <div className="flex flex-col space-y-1">
+          <select className="border p-1" value={option} onChange={(e) => setOption(Number(e.target.value))}>
+            {poll.options.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.text}
+              </option>
+            ))}
+          </select>
+          <input className="border p-1" placeholder="Address" value={address} onChange={(e) => setAddress(e.target.value)} />
+          <input className="border p-1" placeholder="Token Weight" type="number" value={weight} onChange={(e) => setWeight(e.target.value)} />
+          <input className="border p-1" placeholder="Comment" value={comment} onChange={(e) => setComment(e.target.value)} />
+          <button className="bg-primary text-white px-2 py-1 rounded" onClick={submit}>
+            Vote
+          </button>
+        </div>
+      )}
+      {disabled && <p className="italic">Connect a wallet with $KRAUSE to vote.</p>}
+    </div>
+  );
+};
+
+export default function PollsApp() {
+  const { polls, addPoll, vote } = usePolls();
+  const address = useUserAddress();
+  const krauseBalance = useKrauseBalance(address);
+  const canInteract = !!address && parseFloat(krauseBalance || '0') > 0;
+
+  return (
+    <div className="p-4 space-y-4">
+      <PollCreator add={addPoll} disabled={!canInteract} />
+      {polls.map((p) => (
+        <PollCard key={p.id} poll={p} onVote={vote} disabled={!canInteract} />
+      ))}
+    </div>
+  );
+}

--- a/components/home/DesktopIcons.tsx
+++ b/components/home/DesktopIcons.tsx
@@ -11,6 +11,7 @@ export function DesktopIcons() {
     launchProfile,
     launchSearch,
     launchProposalView,
+    launchPolls,
   } = useAppLauncher();
 
   return (
@@ -56,6 +57,17 @@ export function DesktopIcons() {
             alt="Proposals"
           />
           <p className="font-mono">Proposals</p>
+        </div>
+      </button>
+      <button onClick={launchPolls}>
+        <div className="flex flex-col items-center space-y-1">
+          <Image
+            src="/desktop-icons/Doc.png"
+            width={40}
+            height={50}
+            alt="Polls"
+          />
+          <p className="font-mono">Polls</p>
         </div>
       </button>
       {/* <div

--- a/hooks/useAppLauncher.tsx
+++ b/hooks/useAppLauncher.tsx
@@ -3,6 +3,7 @@ import { useAppDispatch } from "@/redux/app/hooks";
 import { launch, open, quitApp } from "@/redux/features/windows/windowsSlice";
 import MyProfile from "../components/apps/UserProfile";
 import ProposalsListPage from "../components/apps/ProposalList";
+import PollsApp from "../components/apps/Polls";
 import SignupModal from "../components/SignupModal";
 
 export const useAppLauncher = () => {
@@ -11,6 +12,7 @@ export const useAppLauncher = () => {
     launchCreateProfile: () => dispatch(launch({ app: <SignupModal /> })),
     launchProfile: () => dispatch(launch({ app: <MyProfile />, padding: 0 })),
     launchProposalView: () => dispatch(launch({ app: <ProposalsListPage /> })),
+    launchPolls: () => dispatch(launch({ app: <PollsApp /> })),
     launchSearch: () => dispatch(open({ windowName: "search" })),
     launchProposal: (id: string) => () =>
       dispatch(launch({ app: <ProposalPage id={id} /> })),

--- a/hooks/usePolls.ts
+++ b/hooks/usePolls.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { Poll, PollOption, Vote } from '@/types/Poll';
+
+const load = (): Poll[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const data = localStorage.getItem('polls');
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+};
+
+export const usePolls = () => {
+  const [polls, setPolls] = useState<Poll[]>(load);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('polls', JSON.stringify(polls));
+    }
+  }, [polls]);
+
+  const addPoll = (question: string, options: string[]) => {
+    const poll: Poll = {
+      id: Date.now().toString(),
+      question,
+      options: options.map((text, i) => ({ id: i, text, votes: [] })),
+    };
+    setPolls((p) => [...p, poll]);
+  };
+
+  const vote = (pollId: string, optionId: number, vote: Vote) => {
+    setPolls((prev) =>
+      prev.map((p) =>
+        p.id === pollId
+          ? {
+              ...p,
+              options: p.options.map((o) =>
+                o.id === optionId ? { ...o, votes: [...o.votes, vote] } : o
+              ),
+            }
+          : p
+      )
+    );
+  };
+
+  return { polls, addPoll, vote };
+};

--- a/pages/polls.tsx
+++ b/pages/polls.tsx
@@ -1,0 +1,19 @@
+import dynamic from 'next/dynamic';
+import Image from 'next/image';
+import { Footer } from '@/components/home/Footer';
+import { DesktopIcons } from '@/components/home/DesktopIcons';
+const Layout = dynamic(() => import('../components/home/Layout'));
+import PollsApp from '@/components/apps/Polls';
+
+export default function PollsPage() {
+  return (
+    <Layout fixedOpen={false} noOpacity={true}>
+      <div className="absolute z-auto -mt-12 flex h-full flex-col justify-center font-mono">
+        <Image src="/LogoGlobe.svg" width={6000} height={6000} alt="logo" />
+      </div>
+      <DesktopIcons />
+      <Footer />
+      <PollsApp />
+    </Layout>
+  );
+}

--- a/types/Poll.ts
+++ b/types/Poll.ts
@@ -1,0 +1,17 @@
+export interface Vote {
+  address: string;
+  weight: number;
+  comment?: string;
+}
+
+export interface PollOption {
+  id: number;
+  text: string;
+  votes: Vote[];
+}
+
+export interface Poll {
+  id: string;
+  question: string;
+  options: PollOption[];
+}


### PR DESCRIPTION
## Summary
- add Poll types to represent votes and poll options
- add `usePolls` hook for storing polls in localStorage
- add `/polls` page to create polls and record weighted votes
- integrate polls as a token-gated mini app with desktop launcher
- add jest test verifying wallet/token gating

## Testing
- `yarn test:ci` *(fails: package not in lockfile)*
- `yarn build` *(fails: package not in lockfile)*